### PR TITLE
SDK 5.1.0: Use new release and use latest translation after update call

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -434,7 +434,7 @@
 			repositoryURL = "https://github.com/phrase/ios-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.0;
+				version = "5.1.0-beta";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -434,7 +434,7 @@
 			repositoryURL = "https://github.com/phrase/ios-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = "5.1.0-beta";
+				version = 5.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -61,9 +61,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             do throws(PhraseUpdateError) {
                 let updated = try await Phrase.shared.updateTranslation()
                 if updated {
-                    // If a translation was used before the update was completed,
-                    // the translations will only be available after restarting the app,
-                    // otherwise the new translations can be used immediately.
+                    // Activate latest updates
+                    Phrase.shared.applyPendingUpdates()
+                    // re-render your UI if needed
                     logger.info("translations changed")
                 } else {
                     logger.debug("translations remain unchanged")


### PR DESCRIPTION
* Add 5.1.0 beta release
* Activate new translation after finished API Call